### PR TITLE
fix: meta mod key on focus handling for gnome/x11

### DIFF
--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -834,10 +834,6 @@ impl<T: 'static> EventProcessor<T> {
                             .focus(xev.event)
                             .expect("Failed to focus input context");
 
-                        let modifiers = ModifiersState::from_x11(&xev.mods);
-
-                        self.device_mod_state.update_state(&modifiers, None);
-
                         if self.active_window != Some(xev.event) {
                             self.active_window = Some(xev.event);
 
@@ -849,12 +845,16 @@ impl<T: 'static> EventProcessor<T> {
                                 event: Focused(true),
                             });
 
-                            if !modifiers.is_empty() {
-                                callback(Event::WindowEvent {
-                                    window_id,
-                                    event: WindowEvent::ModifiersChanged(modifiers),
-                                });
-                            }
+                            // Issue key press events for all pressed keys
+                            Self::handle_pressed_keys(
+                                &wt,
+                                window_id,
+                                ElementState::Pressed,
+                                &mut self.kb_state,
+                                &self.mod_keymap,
+                                &mut self.device_mod_state,
+                                &mut callback,
+                            );
 
                             // The deviceid for this event is for a keyboard instead of a pointer,
                             // so we have to do a little extra work.
@@ -870,22 +870,12 @@ impl<T: 'static> EventProcessor<T> {
                                 event: CursorMoved {
                                     device_id: mkdid(pointer_id),
                                     position,
-                                    modifiers,
+                                    modifiers: self.device_mod_state.modifiers(),
                                 },
                             });
-
-                            // Issue key press events for all pressed keys
-                            Self::handle_pressed_keys(
-                                &wt,
-                                window_id,
-                                ElementState::Pressed,
-                                &mut self.kb_state,
-                                &self.mod_keymap,
-                                &mut self.device_mod_state,
-                                &mut callback,
-                            );
                         }
                     }
+
                     ffi::XI_FocusOut => {
                         let xev: &ffi::XIFocusOutEvent = unsafe { &*(xev.data as *const _) };
                         if !self.window_exists(xev.event) {
@@ -909,11 +899,6 @@ impl<T: 'static> EventProcessor<T> {
                                 &mut self.device_mod_state,
                                 &mut callback,
                             );
-
-                            callback(Event::WindowEvent {
-                                window_id,
-                                event: WindowEvent::ModifiersChanged(ModifiersState::empty()),
-                            });
 
                             callback(Event::WindowEvent {
                                 window_id,
@@ -1059,6 +1044,27 @@ impl<T: 'static> EventProcessor<T> {
                             let text_with_all_modifiers = ker.text_with_all_modifiers();
                             let repeat = xkev.flags & ffi::XIKeyRepeat == ffi::XIKeyRepeat;
 
+                            if let Some(modifier) =
+                                self.mod_keymap.get_modifier(keycode as ffi::KeyCode)
+                            {
+                                let old_modifiers = self.device_mod_state.modifiers();
+
+                                self.device_mod_state.key_event(
+                                    state,
+                                    keycode as ffi::KeyCode,
+                                    modifier,
+                                );
+
+                                if old_modifiers != self.device_mod_state.modifiers() {
+                                    callback(Event::WindowEvent {
+                                        window_id,
+                                        event: WindowEvent::ModifiersChanged(
+                                            self.device_mod_state.modifiers(),
+                                        ),
+                                    });
+                                }
+                            }
+
                             callback(Event::WindowEvent {
                                 window_id,
                                 event: WindowEvent::KeyboardInput {
@@ -1129,14 +1135,6 @@ impl<T: 'static> EventProcessor<T> {
                             return;
                         }
                         let physical_key = keymap::raw_keycode_to_keycode(keycode);
-                        // TODO: Figure out how redundant this is.
-                        //     This is the set of modifiers end users end up seeing. However, the set of
-                        //     modifiers used internally by the `KbState` are sourced directly from the XKB
-                        //     extension. Since we currently panic when the extension doesn't load, we should
-                        //     be able to use the modifiers supplied to us by the XKB extension. This
-                        //     requires us to have consensus on what to do if we can't load and initialize
-                        //     libxkbcommon.
-                        let modifiers = self.device_mod_state.modifiers();
 
                         callback(Event::DeviceEvent {
                             device_id,
@@ -1145,27 +1143,6 @@ impl<T: 'static> EventProcessor<T> {
                                 state,
                             }),
                         });
-
-                        if let Some(modifier) =
-                            self.mod_keymap.get_modifier(keycode as ffi::KeyCode)
-                        {
-                            self.device_mod_state.key_event(
-                                state,
-                                keycode as ffi::KeyCode,
-                                modifier,
-                            );
-
-                            let new_modifiers = self.device_mod_state.modifiers();
-
-                            if modifiers != new_modifiers {
-                                if let Some(window_id) = self.active_window {
-                                    callback(Event::WindowEvent {
-                                        window_id: mkwid(window_id),
-                                        event: WindowEvent::ModifiersChanged(new_modifiers),
-                                    });
-                                }
-                            }
-                        }
                     }
 
                     ffi::XI_HierarchyChanged => {
@@ -1316,11 +1293,16 @@ impl<T: 'static> EventProcessor<T> {
             let text_with_all_modifiers = ker.text_with_all_modifiers();
 
             if let Some(modifier) = mod_keymap.get_modifier(keycode as ffi::KeyCode) {
-                device_mod_state.key_event(
-                    ElementState::Pressed,
-                    keycode as ffi::KeyCode,
-                    modifier,
-                );
+                let old_modifiers = device_mod_state.modifiers();
+
+                device_mod_state.key_event(state, keycode as ffi::KeyCode, modifier);
+
+                if old_modifiers != device_mod_state.modifiers() {
+                    callback(Event::WindowEvent {
+                        window_id,
+                        event: WindowEvent::ModifiersChanged(device_mod_state.modifiers()),
+                    });
+                }
             }
 
             callback(Event::WindowEvent {


### PR DESCRIPTION
This patch addresses an issue in the modifier key handling appearing on
gnome/x11 while focussing a winit window using a meta/super/logo key
shortcut.

As soon as the window gained focus via a shortcut using a meta key,
gnome/x11 reports a meta modifier as pressed in the focus event, even
though it was just released. No key release events were sent afterwards,
so the meta modifier remained "stuck" in the winit state.

This patch refactors the modifier key handling following this goals:
 - Only rely on winit's own modifier state tracking for key and focus
   events, do not mix it with x11's modifier reporting
 - Track modifiers only via non-raw key events, so winit does not track
   modifier changes when not focussed
 - Integrate modifier handling with the synthetic key events mechanism
   in order to report release of all currently held modifiers when
   unfocussed and report set for all currently held modifiers when
   focussed.

If you wonder why somebody is creating a pull request for a branch currently being in a pull request for the upstream repo... For https://github.com/neovide/neovide @kethku created a winit branch https://github.com/kethku/winit/tree/new-keyboard-all pulling in this very WIP branch already for the current neovide main branch. I am running neovide main and experienced the before mentioned problem on my platform. So I tried to fix it.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
