### PR TITLE
X11: Don't listen for global pointer button changes

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -262,10 +262,26 @@ impl<T: 'static> EventLoop<T> {
             .xconn
             .select_xkb_events(
                 0x100, // Use the "core keyboard device"
-                ffi::XkbNewKeyboardNotifyMask | ffi::XkbMapNotifyMask | ffi::XkbStateNotifyMask,
+                ffi::XkbNewKeyboardNotifyMask | ffi::XkbMapNotifyMask,
             )
             .unwrap()
             .queue();
+
+        #[allow(non_upper_case_globals)]
+        {
+            // TODO: Remove constants after https://github.com/AltF02/x11-rs/pull/133 is published
+            const XkbPointerButtonMask: c_ulong = 1 << 13;
+            const XkbAllStateComponentsMask: c_ulong = 0x3fff;
+            get_xtarget(&target)
+                .xconn
+                .select_xkb_event_details(
+                    0x100, // Use the "core keyboard device"
+                    ffi::XkbStateNotify as c_uint,
+                    XkbAllStateComponentsMask & !XkbPointerButtonMask,
+                )
+                .unwrap()
+                .queue();
+        }
 
         event_processor.init_device(ffi::XIAllDevices);
 

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -91,6 +91,23 @@ impl XConnection {
         }
     }
 
+    pub fn select_xkb_event_details(
+        &self,
+        device_id: c_uint,
+        event: c_uint,
+        mask: c_ulong,
+    ) -> Option<Flusher<'_>> {
+        let status = unsafe {
+            (self.xlib.XkbSelectEventDetails)(self.display, device_id, event, mask, mask)
+        };
+        if status == ffi::True {
+            Some(Flusher::new(self))
+        } else {
+            error!("Could not select XKB events: The XKB extension is not initialized!");
+            None
+        }
+    }
+
     pub fn query_pointer(
         &self,
         window: ffi::Window,


### PR DESCRIPTION
These changes are not used by winit and cause unnecessary wakeups.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
