### PR TITLE
X11: Only fetch virtual keyboard events from master devices

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -626,9 +626,7 @@ impl Device {
                 | ffi::XI_RawButtonPressMask
                 | ffi::XI_RawButtonReleaseMask
                 | ffi::XI_RawKeyPressMask
-                | ffi::XI_RawKeyReleaseMask
-                | ffi::XI_KeyPressMask
-                | ffi::XI_KeyReleaseMask;
+                | ffi::XI_RawKeyReleaseMask;
             // The request buffer is flushed when we poll for events
             wt.xconn
                 .select_xinput_events(wt.root, info.deviceid, mask)

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -407,8 +407,8 @@ impl UnownedWindow {
                 let mask = ffi::XI_MotionMask
                     | ffi::XI_ButtonPressMask
                     | ffi::XI_ButtonReleaseMask
-                    //| ffi::XI_KeyPressMask
-                    //| ffi::XI_KeyReleaseMask
+                    | ffi::XI_KeyPressMask
+                    | ffi::XI_KeyReleaseMask
                     | ffi::XI_EnterMask
                     | ffi::XI_LeaveMask
                     | ffi::XI_FocusInMask


### PR DESCRIPTION
We must not report virtual keyboard events for keys that were grabbed by
other applications (XGrabKey, etc.). Since grabs only affect master
devices, we must consume virtual events from master devices only.